### PR TITLE
Adjust mobile navigation breakpoint

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -350,7 +350,7 @@ input:focus-visible,textarea:focus-visible{
   .grid--two{grid-template-columns:1.2fr .8fr}
 }
 
-@media (min-width:768px){
+@media (max-width:1023px){
   .hamburger{display:inline-grid}
   .nav{
     position:fixed;inset:60px 0 auto 0;padding:16px;background:rgba(17,24,38,0.98);


### PR DESCRIPTION
## Summary
- use a max-width 1023px media query for mobile navigation
- keep desktop navigation styles for wider screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acdbcc07b48333a5d55afbf5d2a48d